### PR TITLE
Fixed bug where "issues" generated by linter-prolog have an incorrect path

### DIFF
--- a/lib/linter-provider.coffee
+++ b/lib/linter-provider.coffee
@@ -7,6 +7,7 @@ module.exports = class LinterProvider
     \s+     #A space.
     (\S+):  #The file with issue.
     (\d+):  #The line number with issue.
+    (\d+):  #The column number with issue.
     \s+     #A space.
     (.*)    #A message explaining the issue at hand.
   ///
@@ -22,8 +23,8 @@ module.exports = class LinterProvider
 
   parse = (line, cwd) ->
     if line.match swi_regex
-      [type, file, line, message] = line.match(swi_regex)[1..4]
-      return [file, line, 0, type, message]
+      [type, file, line, column, message] = line.match(swi_regex)[1..5]
+      return [file, line, column, type, message]
     lines = line.split("\n")
     if lines[0].endsWith("error")
       message = lines[1].substring(2)
@@ -53,7 +54,7 @@ module.exports = class LinterProvider
             toReturn.push(
               type: type,
               text: message,
-              filePath: path.join(cwd, file).normalize()
+              filePath: file.normalize()
               range: [[line - 1, column - 1], [line - 1, column - 1]]
             )
         Resolve toReturn


### PR DESCRIPTION
Atom version: 1.0.7
SWI-Prolog version: 7.2.2

Example of the bug: (the correct path is "/home/elon/Universiteit/Zoektechnieken/Homework/Homework.pl")
![atom_linter-prolog_incorrect_path](https://cloud.githubusercontent.com/assets/5054902/9786075/6d314512-57b7-11e5-9115-7e950686d289.png)

I've only tested this on my system; considering the fact that there's no bug report for the issue I'm experiencing, it's possible that this issue only occurs on my system. 
The regex isn't correct for my version of SWI-Prolog. When I run the SWI-Prolog linter on a Prolog-file with a single issue, it outputs:
"ERROR: /home/elon/Universiteit/Zoektechnieken/Homework/Homework.pl:82:11: Syntax error: Operator expected". The regex doesn't include the column number, resulting in incorrect parsing.

Also, at least on my system, "path.basename TextEditor.getPath()" actually evaluates to the full path (weird). Consequently, "path.join(cwd, file)" then evaluates to an incorrect path.

I've no idea whether this issue occurs on other systems as well, but feel free to use any of this if it does.
