### PR TITLE
Support Windows file path drive letters

### DIFF
--- a/lib/linter-provider.coffee
+++ b/lib/linter-provider.coffee
@@ -5,6 +5,7 @@ module.exports = class LinterProvider
   swi_regex = ///
     (\w+):  #The type of issue being reported.
     \s+     #A space.
+    (?:\w:)? #The drive letter of the file (Windows-specific).
     [^\:]+:  #The file with issue.
     (\d+):  #The line number with issue.
     ((\d+):)?  #The column number with issue.


### PR DESCRIPTION
The drive letter (like `e:`) in Windows file paths currently breaks the regular expression used to parse lint messages from Prolog (SWI-Prolog, at least). The effect is that `linter-prolog` won't report issues when it should. This PR should fix that.

I haven't added any tests because I'm not sure how I should write a Platform-specific test. Also, the current tests fail on my Windows machine without this PR.