### PR TITLE
Report all errors/warnings from swipl/sicstus

### DIFF
--- a/spec/linter-prolog-spec.js
+++ b/spec/linter-prolog-spec.js
@@ -76,4 +76,14 @@ describe('The prolog-linter for AtomLinter', () => {
       });
     });
   });
+
+  it('finds multiple diagnostics in a file with a warning and an error', () => {
+    waitsForPromise(() => {
+      return atom.workspace.open(__dirname + '/test_files/multiple_diagnostics.pl').then(editor => {
+        return lint(editor).then(messages => {
+          expect(messages.length).toBeGreaterThan(1);
+        });
+      });
+    });
+  });
 });

--- a/spec/test_files/multiple_diagnostics.pl
+++ b/spec/test_files/multiple_diagnostics.pl
@@ -1,0 +1,5 @@
+hello(X, Y) :-
+  write('Hello, '),
+  write(X),
+  nl.
+fgbfgb


### PR DESCRIPTION
This PR adds support for reporting multiple errors and/or warnings. (I haven't used linter-prolog in a while, so maybe this has already been fixed?)